### PR TITLE
Miscellaneous improvements to the test-connection-disruption client

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -14,7 +14,7 @@ import (
 
 const MSG_SIZE = 256 // should be synced with the server
 
-var DispatchInterval uint32
+var DispatchInterval time.Duration
 
 func panicOnErr(ctx string, err error) {
 	if err != nil {
@@ -23,7 +23,7 @@ func panicOnErr(ctx string, err error) {
 }
 
 func main() {
-	flag.Uint32Var(&DispatchInterval, "dispatch-interval", 500, "TCP packet dispatch interval in milliseconds")
+	flag.DurationVar(&DispatchInterval, "dispatch-interval", 500*time.Millisecond, "TCP packet dispatch interval")
 	flag.Parse()
 
 	var (
@@ -79,6 +79,6 @@ func main() {
 			panic(fmt.Sprintf("Invalid reply(%v) for request(%v)", reply, request))
 		}
 
-		time.Sleep(time.Duration(DispatchInterval) * time.Millisecond)
+		time.Sleep(DispatchInterval)
 	}
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -75,7 +75,7 @@ func main() {
 		case <-time.After(1 * time.Second):
 			panic("conn.Read timed out")
 		}
-		if bytes.Compare(request, reply) != 0 {
+		if !bytes.Equal(request, reply) {
 			panic(fmt.Sprintf("Invalid reply(%v) for request(%v)", reply, request))
 		}
 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"sync/atomic"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -49,6 +50,14 @@ func main() {
 	request := make([]byte, MSG_SIZE)
 	reply := make([]byte, MSG_SIZE)
 
+	var count atomic.Int64
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		for range ticker.C {
+			fmt.Printf("Operations per second: %d\n", count.Swap(0))
+		}
+	}()
+
 	for {
 		_, err := rand.Read(request)
 		panicOnErr("rand.Read", err)
@@ -79,6 +88,7 @@ func main() {
 			panic(fmt.Sprintf("Invalid reply(%v) for request(%v)", reply, request))
 		}
 
+		count.Add(1)
 		time.Sleep(DispatchInterval)
 	}
 }


### PR DESCRIPTION
Please review commit by commit, and refer to the individual messages for additional details. A brief summary follows:

* Convert the dispatch-interval parameter to duration type, to allow configuring sub-millisecond values;
* Fix linting error by replacing bytes.Compare with bytes.Equal;
* Log the number of operations per second, to simplify troubleshooting in constrained CPU environments;
* Replace the custom timeout logic with Set{Write,Read}Deadline, which introduce less overhead.

Please note that the parameter type change will require a corresponding modification on the Cilium CLI repo. 