### PR TITLE
Connectivity disruption test overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-TAG ?= v0.0.10
+TAG ?= v0.0.15
 IMAGE ?= quay.io/cilium/test-connection-disruption
 GOOS ?= linux
 GOARCH ?= amd64

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -2,79 +2,235 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/signal"
+	"runtime"
 	"sync/atomic"
 	"time"
 
 	flag "github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cilium/test-connection-disruption/internal"
 )
 
-const MSG_SIZE = 256 // should be synced with the server
+const maxAttempts = 30
 
-var DispatchInterval time.Duration
+func init() {
+	internal.ErrExit("being nice", internal.BeNice())
+}
 
-func panicOnErr(ctx string, err error) {
-	if err != nil {
-		panic(fmt.Sprintf("%s: %s", ctx, err))
-	}
+var stats struct {
+	rx, tx atomic.Uint64
+	bytes  atomic.Uint64
+}
+
+var args struct {
+	addr     string
+	interval time.Duration
+	latency  time.Duration
 }
 
 func main() {
-	flag.DurationVar(&DispatchInterval, "dispatch-interval", 500*time.Millisecond, "TCP packet dispatch interval")
+	flag.DurationVar(&args.interval, "dispatch-interval", 50*time.Millisecond, "TCP packet dispatch interval")
+	flag.DurationVar(&args.latency, "latency", 250*time.Millisecond, "Maximum expected latency for the connection, used for setting read deadlines")
 	flag.Parse()
 
-	var (
-		conn net.Conn
-		err  error
-	)
-	addr := flag.Args()[0]
+	args.addr = flag.Arg(0)
+	if args.addr == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
 
-	for i := 0; i < 30; i++ {
-		conn, err = net.Dial("tcp", addr)
+	// For backwards compatibility, clamp the interval to a minimum of 1ms.
+	// Before the rewrite, 0ms meant roughly 5k pps due to latency, but now
+	// 500k pps can be achieved by disabling the interval.
+	if args.interval == 0 {
+		args.interval = 500 * time.Microsecond
+		fmt.Println("Zero interval changed to", args.interval, "for backwards compatibility, otherwise bufferbloat will interfere.")
+	}
+
+	conn, err := dial()
+	internal.ErrExit("dial remote", err)
+	defer conn.Close()
+
+	// Set up request payload.
+	request := make([]byte, internal.MsgSize)
+	_, err = rand.Read(request)
+	internal.ErrExit("generate random payload", err)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	var eg errgroup.Group
+	eg.Go(writer(ctx, cancel, conn, request))
+	eg.Go(reader(ctx, cancel, conn, request))
+
+	startLogger()
+
+	ready()
+
+	internal.ErrExit("Error in writer or reader", eg.Wait())
+}
+
+func dial() (net.Conn, error) {
+	var conn net.Conn
+	var err error
+	for range maxAttempts {
+		conn, err = net.Dial("tcp", args.addr)
 		if err == nil {
 			break
 		}
-		fmt.Printf("Failed to connect to %s due to %s. Retrying...\n", addr, err)
-		time.Sleep(1 * time.Second)
+		fmt.Printf("Failed to connect to %s due to %s. Retrying...\n", args.addr, err)
+		time.Sleep(time.Second)
 	}
-	panicOnErr("Failed to connect", err)
+	if err != nil {
+		return nil, err
+	}
+
 	fmt.Printf("Connected to %s from %s\n", conn.RemoteAddr(), conn.LocalAddr())
-	file, err := os.Create("/tmp/client-ready")
-	panicOnErr("Failed to create file", err)
-	file.Close()
 
-	request := make([]byte, MSG_SIZE)
-	reply := make([]byte, MSG_SIZE)
+	return conn, nil
+}
 
-	var count atomic.Int64
+func startLogger() {
 	go func() {
 		ticker := time.NewTicker(time.Second)
 		for range ticker.C {
-			fmt.Printf("Operations per second: %d\n", count.Swap(0))
+			fmt.Printf("Operations per second: tx %d, rx %d, %s/s\n", stats.tx.Swap(0), stats.rx.Swap(0), internal.ByteString(stats.bytes.Swap(0)))
 		}
 	}()
+}
 
-	for {
-		_, err := rand.Read(request)
-		panicOnErr("rand.Read", err)
+func writer(ctx context.Context, cancel context.CancelFunc, conn net.Conn, request []byte) func() error {
+	return func() error {
+		// Stop the reader when the writer is done, or the ErrGroup will wait forever.
+		defer cancel()
 
-		panicOnErr("conn.SetWriteDeadline", conn.SetWriteDeadline(time.Now().Add(1*time.Second)))
-		_, err = conn.Write(request)
-		panicOnErr("conn.Write", err)
+		// Start off with the configured packet interval. This will be adjusted
+		// based on the time it took to write to the socket.
+		pause := args.interval
 
-		panicOnErr("conn.SetReadDeadline", conn.SetReadDeadline(time.Now().Add(1*time.Second)))
-		_, err = io.ReadFull(conn, reply)
-		panicOnErr("io.ReadFull", err)
+		// Lock the goroutine to the current OS thread to prevent the runtime from
+		// migrating and interrupting it as often. We're manually calling nanosleep,
+		// bypassing the runtime's scheduler, to get somewhat accurate sleep
+		// behaviour.
+		runtime.LockOSThread()
 
-		if !bytes.Equal(request, reply) {
-			panic(fmt.Sprintf("Invalid reply(%v) for request(%v)", reply, request))
+		fmt.Println("Sending requests at a target interval of", args.interval, "with max expected latency of", args.latency)
+
+		for {
+			// Immediately stop producing packets when the client is shutting down.
+			select {
+			case <-ctx.Done():
+				fmt.Println("Writer shutting down")
+				return nil
+			default:
+			}
+
+			start := time.Now()
+
+			if err := conn.SetWriteDeadline(start.Add(time.Second)); err != nil {
+				return fmt.Errorf("set write deadline: %w", err)
+			}
+
+			n, err := conn.Write(request)
+			if err != nil {
+				return fmt.Errorf("conn write: %w", err)
+			}
+			if n != len(request) {
+				return fmt.Errorf("short write: %d", n)
+			}
+
+			stats.tx.Add(1)
+
+			// Sleep for the duration determined during the previous round. Use a
+			// direct call to nanosleep(2) since the regular [time.Sleep] is
+			// implemented by the Go runtime and gets coalesced to reduce syscall
+			// overhead. This leads to wildly unexpected sleep durations.
+			internal.Sleep(pause)
+
+			// Adjust the sleep interval for the next cycle based on the time it took
+			// to write to the socket and when the OS scheduler woke us up.
+			delta := args.interval - time.Since(start)
+
+			// Smoothen the approach to the target interval by adjusting the pause
+			// interval by half the delta.
+			pause += (delta / 2)
+
+			// Ensure pause stays within bounds. On a permanent deficit, it would
+			// run negative and overflow at some point.
+			pause = min(max(pause, -args.interval), args.interval)
 		}
-
-		count.Add(1)
-		time.Sleep(DispatchInterval)
 	}
+}
+
+func reader(ctx context.Context, cancel context.CancelFunc, conn net.Conn, request []byte) func() error {
+	return func() error {
+		// Stop the reader when the writer is done, or the ErrGroup will wait forever.
+		defer cancel()
+
+		reply := make([]byte, internal.MsgSize)
+		for {
+			deadline := args.interval + args.latency
+			if err := conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
+				return fmt.Errorf("set read deadline: %w", err)
+			}
+
+			_, err := io.ReadFull(conn, reply)
+			// Allow the reader to drain replies before shutting down instead of
+			// closing the connection immediately. This reduces the chance of the
+			// server seeing a connection reset, which causes red herrings in the
+			// server logs when finding potential conn disruptions.
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				// Check if the deadline was exceeded as a consequence of shutting down.
+				// Require the reader to be fully caught up at this point.
+				select {
+				case <-ctx.Done():
+					if stats.tx.Load() == stats.rx.Load() {
+						fmt.Println("Reader shutting down")
+						return nil
+					}
+				default:
+				}
+
+				return fmt.Errorf("no reply received within %v deadline: %w (%d tx, %d rx)", deadline, err, stats.tx.Load(), stats.rx.Load())
+			}
+			if errors.Is(err, io.EOF) {
+				fmt.Println("Server closed the connection")
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("read reply: %w", err)
+			}
+
+			if !bytes.Equal(request, reply) {
+				return fmt.Errorf("invalid reply(%v) to request(%v)", reply, request)
+			}
+
+			stats.rx.Add(1)
+			stats.bytes.Add(internal.MsgSize)
+
+			// Check if we're shutting down and reader fully caught up to the writer,
+			// for a fast exit.
+			select {
+			case <-ctx.Done():
+				if stats.tx.Load() == stats.rx.Load() {
+					fmt.Println("Reader shutting down")
+					return nil
+				}
+			default:
+			}
+		}
+	}
+}
+
+func ready() {
+	file, err := os.Create("/tmp/client-ready")
+	internal.ErrExit("create ready file", err)
+	internal.ErrExit("close ready file", file.Close())
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,52 +1,116 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/signal"
+	"sync"
+
+	"github.com/cilium/test-connection-disruption/internal"
 )
 
-const MSG_SIZE = 256 // should be synced with the client
-
-func panicOnErr(ctx string, err error) {
-	if err != nil {
-		panic(fmt.Sprintf("%s: %s", ctx, err))
-	}
-}
-
-func read(conn net.Conn) {
-	fmt.Println("New connection from", conn.RemoteAddr())
-	defer conn.Close()
-	buf := make([]byte, MSG_SIZE)
-	for {
-		_, err := io.ReadFull(conn, buf)
-		if err != nil {
-			fmt.Println("Closed connection from", conn.RemoteAddr(), err)
-			return
-		}
-		_, err = conn.Write(buf)
-		if err != nil {
-			fmt.Println("Closed connection to", conn.RemoteAddr(), err)
-			return
-		}
-	}
+func init() {
+	internal.ErrExit("being nice", internal.BeNice())
 }
 
 func main() {
-	port := os.Args[1]
-	listen, err := net.Listen("tcp", ":"+port)
-	panicOnErr("net.Listen", err)
-
-	file, err := os.Create("/tmp/server-ready")
-	panicOnErr("Failed to create file", err)
-	file.Close()
-
-	fmt.Printf("Listening on %s...\n", port)
-
-	for {
-		conn, err := listen.Accept()
-		panicOnErr("Accept", err)
-		go read(conn)
+	flag.Parse()
+	port := flag.Arg(0)
+	if port == "" {
+		fmt.Println("Usage: server <port>")
+		os.Exit(1)
 	}
+
+	listen, err := net.Listen("tcp", ":"+port)
+	internal.ErrExit("listen", err)
+
+	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
+	go func() {
+		<-ctx.Done()
+		fmt.Println("Closing listener")
+		listen.Close()
+	}()
+
+	ready()
+
+	fmt.Printf("Listening on port %s...\n", port)
+
+	wg := &sync.WaitGroup{}
+	accept(ctx, wg, listen)
+
+	wg.Wait()
+}
+
+func accept(ctx context.Context, wg *sync.WaitGroup, listen net.Listener) {
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			conn, err := listen.Accept()
+			if errors.Is(err, net.ErrClosed) {
+				fmt.Println("Listener closed")
+				return
+			}
+			internal.ErrExit("accept conn", err)
+
+			read(ctx, wg, conn)
+		}
+	}()
+}
+
+func read(ctx context.Context, wg *sync.WaitGroup, conn net.Conn) {
+	wg.Add(1)
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-ctx.Done()
+		fmt.Println("Closing connection to", conn.RemoteAddr())
+		conn.Close()
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Make sure context done channel unblocks when the reader exits so we don't
+		// leak the goroutine created above.
+		defer cancel()
+
+		fmt.Println("New connection from", conn.RemoteAddr())
+		defer conn.Close()
+
+		// Read+write one message at a time.
+		buf := make([]byte, internal.MsgSize)
+		for {
+			_, err := io.ReadFull(conn, buf)
+			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading from %s: %s\n", conn.RemoteAddr(), err)
+				return
+			}
+
+			_, err = conn.Write(buf)
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error writing to %s: %s\n", conn.RemoteAddr(), err)
+				return
+			}
+		}
+	}()
+}
+
+func ready() {
+	file, err := os.Create("/tmp/server-ready")
+	internal.ErrExit("create ready file", err)
+	internal.ErrExit("close ready file", file.Close())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/cilium/test-connection-disruption
 
-go 1.20
+go 1.23
 
-require github.com/spf13/pflag v1.0.5
+require (
+	github.com/spf13/pflag v1.0.5
+	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
+	golang.org/x/sync v0.10.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c h1:KL/ZBHXgKGVmuZBZ01Lt57yE5ws8ZPSkkihmEyq7FXc=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
+golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -1,0 +1,61 @@
+package internal
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/exp/constraints"
+)
+
+const MsgSize = 16
+
+// ErrExit prints the message and error to stderr and exits with status 1 if err
+// is not nil.
+func ErrExit(msg string, err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: %s\n", msg, err)
+		os.Exit(1)
+	}
+}
+
+// BeNice sets the calling process' priority to the lowest possible value.
+func BeNice() error {
+	if err := syscall.Setpriority(syscall.PRIO_PROCESS, os.Getpid(), 19); err != nil {
+		return fmt.Errorf("set priority: %w", err)
+	}
+	return nil
+}
+
+// Sleep for the specified duration. No-op if d is negative or zero.
+func Sleep(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+
+	ts := syscall.NsecToTimespec(d.Nanoseconds())
+	err := syscall.Nanosleep(&ts, nil)
+	switch err {
+	case nil, syscall.EINTR:
+		// Interrupted sleep is fine for our purposes.
+	case syscall.EINVAL:
+		panic(fmt.Sprintf("nanosleep interval %s out of range: %s", d, err))
+	default:
+		panic(fmt.Sprintf("nanosleep: %s", err))
+	}
+}
+
+// ByteString returns a human-readable string representation of the given byte
+// count. Taken from https://stackoverflow.com/a/1094933/1333724.
+func ByteString[T constraints.Integer](b T) string {
+	bf := float64(b)
+	for _, unit := range []string{"", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"} {
+		if math.Abs(bf) < 1024.0 {
+			return fmt.Sprintf("%3.1f%sB", bf, unit)
+		}
+		bf /= 1024.0
+	}
+	return fmt.Sprintf("%.1fYiB", bf)
+}


### PR DESCRIPTION
This commit/PR makes many improvements to both the client and server that would be tricky to split up into smaller commits, as the program was relatively compact and the changes themselves aren't very layered. As a result, this has basically turned into a rewrite of the client (sorry). Here's a small overview:

## Client

- Made the writer and reader asynchronous to allow for accurate packet scheduling. Before, writing and reading happened in a single loop, which puts a hard limit on the packet rate since latency is the dominating factor. (unless sleep() is removed)
- Message size reduced to 16 bytes since we're more interested in testing pps than throughput. This cuts out a significant part of the CPU consumption, which was starting to weigh on Cilium CI where this stack is run.
- Dynamic sleep interval based on socket write duration + scheduler jitter. The client will automatically try to attain the requested packet interval, enqueueing packets as evenly-spaced as possible. This was completely broken in the initial implementation, since latency wasn't accounted for. See below for example output.
- Added a --latency flag to directly control the read timeout for replies.
- dispatch-interval=0 no longer busy-polls and is automatically rewritten to 500us for backwards compatibility purposes. Existing Cilium tests currently specify 0ms to send packets as fast as possible, but with the new implementation, this will quickly fill the tx buffer and give the tcp stack a small meltdown.
- Client set itself to nice19 to avoid stealing too much CPU time from the Cilium agent in resource-constrained environments. (aka. 4-core LVH VMs with 3-node kind clusters)
- Writer is now pinned to an OS thread to reduce scheduling jitter caused by the Go runtime.
- nanosleep(2) is called directly from the writer goroutine to avoid the Go runtime's sleep coalescing and throttling. (see `strace -fenanosleep` on a typical Go program calling time.Sleep() in a tight loop)
- The client now does a best effort to exit gracefully to avoid connection resets being logged on the server, which otherwise pollutes the log.

## Server

- Moved most of the code out of main().
- Sets itself to nice19 like the client.
- Close all sockets before terminating.

On the server side, I experimented with graceful termination/socket draining, but since the client drives message production, sending a signal to the client to terminate would involve introducing a higher-level protocol. If the server Pod is shut down, that typically means the whole test namespace is being killed, so clean logs aren't much of a priority in that case.

Some example output of the client:

```
~ go run ./cmd/client localhost:1234 --dispatch-interval 0
Zero interval changed to 500µs for backwards compatibility, otherwise bufferbloat will interfere.
Connected to [::1]:1234 from [::1]:34620
Sending requests at a target interval of 500µs with max expected latency of 250ms
Operations per second: tx 2001, rx 2001, 31.3KiB/s
Operations per second: tx 2001, rx 2001, 31.3KiB/s
^CReader shutting down
Writer shutting down
```