### PR TITLE
client: reduce packet rate, add timeout mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-TAG ?= v0.0.15
+TAG ?= v0.0.16
 IMAGE ?= quay.io/cilium/test-connection-disruption
 GOOS ?= linux
 GOARCH ?= amd64

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -48,12 +48,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// For backwards compatibility, clamp the interval to a minimum of 1ms.
-	// Before the rewrite, 0ms meant roughly 5k pps due to latency, but now
-	// 500k pps can be achieved by disabling the interval.
+	// For backwards compatibility, clamp the interval to a minimum of 10ms to
+	// avoid overloading resource-constrained CI machines where Cilium runs with
+	// monitor aggregation disabled.
 	if args.interval == 0 {
-		args.interval = 500 * time.Microsecond
-		fmt.Println("Zero interval changed to", args.interval, "for backwards compatibility, otherwise bufferbloat will interfere.")
+		args.interval = 10 * time.Millisecond
+		fmt.Println("Zero interval changed to", args.interval, "for backwards compatibility.")
 	}
 
 	conn, err := dial()


### PR DESCRIPTION
Shortening the read deadline proved quite fragile under resource constraints, especially since the client is now running at nice19. Give the reader a chance to catch up by using a timeout instead, defaulting to 5 seconds.

Also reduced the packet rate per client to 100pps down from 2000pps, since multiple CI jobs are failing due to high CPU load and the tight deadline. Cilium runs with monitor aggregation disabled in CI, so we need to be mindful.