### PR TITLE
Add http client and server implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILDER
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.25 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.25 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 GO ?= go
-TAG ?= v0.0.16
+TAG ?= v0.0.17
 IMAGE ?= quay.io/cilium/test-connection-disruption
 GOOS ?= linux
 GOARCH ?= amd64
 
 all: client server
 
+.PHONY: client
 client: cmd/client
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -a -ldflags '-extldflags "-static"' ./cmd/client
 
+.PHONY: server
 server: cmd/server
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -a -ldflags '-extldflags "-static"' ./cmd/server
 

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,49 +1,31 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"crypto/rand"
-	"errors"
 	"fmt"
-	"io"
-	"net"
 	"os"
 	"os/signal"
-	"runtime"
-	"sync/atomic"
 	"time"
 
 	flag "github.com/spf13/pflag"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/cilium/test-connection-disruption/internal"
+	"github.com/cilium/test-connection-disruption/pkg/common"
+	"github.com/cilium/test-connection-disruption/pkg/tcp"
 )
-
-const maxAttempts = 30
 
 func init() {
 	internal.ErrExit("being nice", internal.BeNice())
 }
 
-var stats struct {
-	rx, tx atomic.Uint64
-	bytes  atomic.Uint64
-}
-
-var args struct {
-	addr     string
-	interval time.Duration
-	timeout  time.Duration
-}
-
 func main() {
-	flag.DurationVar(&args.interval, "dispatch-interval", 50*time.Millisecond, "TCP packet dispatch interval")
-	flag.DurationVar(&args.timeout, "timeout", 5*time.Second, "Client exits when no reply is received within this duration")
+	cc := common.ClientConfig{}
+	cc.RegisterFlags()
 	flag.Parse()
 
-	args.addr = flag.Arg(0)
-	if args.addr == "" {
+	cc.ProtocolConfig.Address = flag.Arg(0)
+	if cc.ProtocolConfig.Address == "" {
+		fmt.Println("Usage: client --protocol <tcp> <port/address>")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -51,192 +33,21 @@ func main() {
 	// For backwards compatibility, clamp the interval to a minimum of 10ms to
 	// avoid overloading resource-constrained CI machines where Cilium runs with
 	// monitor aggregation disabled.
-	if args.interval == 0 {
-		args.interval = 10 * time.Millisecond
-		fmt.Println("Zero interval changed to", args.interval, "for backwards compatibility.")
+	if cc.Interval == 0 {
+		cc.Interval = 10 * time.Millisecond
+		fmt.Println("Zero interval changed to", cc.Interval, "for backwards compatibility.")
 	}
 
-	conn, err := dial()
-	internal.ErrExit("dial remote", err)
-	defer conn.Close()
+	var handler common.ProtocolHandler
 
-	// Set up request payload.
-	request := make([]byte, internal.MsgSize)
-	_, err = rand.Read(request)
-	internal.ErrExit("generate random payload", err)
+	switch common.Protocol(cc.Protocol) {
+	case common.ProtocolTCP:
+		handler = tcp.NewTcpClient(cc)
+	default:
+		fmt.Printf("Invalid Protocol: %s\n", cc.Protocol)
+		os.Exit(1)
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
-	var eg errgroup.Group
-	eg.Go(writer(ctx, cancel, conn, request))
-	eg.Go(reader(ctx, cancel, conn, request))
-
-	startLogger()
-
-	ready()
-
-	internal.ErrExit("Error in writer or reader", eg.Wait())
-}
-
-func dial() (net.Conn, error) {
-	var conn net.Conn
-	var err error
-	for range maxAttempts {
-		conn, err = net.Dial("tcp", args.addr)
-		if err == nil {
-			break
-		}
-		fmt.Printf("Failed to connect to %s due to %s. Retrying...\n", args.addr, err)
-		time.Sleep(time.Second)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	fmt.Printf("Connected to %s from %s\n", conn.RemoteAddr(), conn.LocalAddr())
-
-	return conn, nil
-}
-
-func startLogger() {
-	go func() {
-		ticker := time.NewTicker(time.Second)
-		for range ticker.C {
-			fmt.Printf("Operations per second: tx %d, rx %d, %s/s\n", stats.tx.Swap(0), stats.rx.Swap(0), internal.ByteString(stats.bytes.Swap(0)))
-		}
-	}()
-}
-
-func writer(ctx context.Context, cancel context.CancelFunc, conn net.Conn, request []byte) func() error {
-	return func() error {
-		// Stop the reader when the writer is done, or the ErrGroup will wait forever.
-		defer cancel()
-
-		// Start off with the configured packet interval. This will be adjusted
-		// based on the time it took to write to the socket.
-		pause := args.interval
-
-		// Lock the goroutine to the current OS thread to prevent the runtime from
-		// migrating and interrupting it as often. We're manually calling nanosleep,
-		// bypassing the runtime's scheduler, to get somewhat accurate sleep
-		// behaviour.
-		runtime.LockOSThread()
-
-		fmt.Println("Sending requests at a target interval of", args.interval, "with timeout of", args.timeout)
-
-		for {
-			// Immediately stop producing packets when the client is shutting down.
-			select {
-			case <-ctx.Done():
-				fmt.Println("Writer shutting down")
-				return nil
-			default:
-			}
-
-			start := time.Now()
-
-			if err := conn.SetWriteDeadline(start.Add(time.Second)); err != nil {
-				return fmt.Errorf("set write deadline: %w", err)
-			}
-
-			n, err := conn.Write(request)
-			if err != nil {
-				return fmt.Errorf("conn write: %w", err)
-			}
-			if n != len(request) {
-				return fmt.Errorf("short write: %d", n)
-			}
-
-			stats.tx.Add(1)
-
-			// Sleep for the duration determined during the previous round. Use a
-			// direct call to nanosleep(2) since the regular [time.Sleep] is
-			// implemented by the Go runtime and gets coalesced to reduce syscall
-			// overhead. This leads to wildly unexpected sleep durations.
-			internal.Sleep(pause)
-
-			// Adjust the sleep interval for the next cycle based on the time it took
-			// to write to the socket and when the OS scheduler woke us up.
-			delta := args.interval - time.Since(start)
-
-			// Smoothen the approach to the target interval by adjusting the pause
-			// interval by half the delta.
-			pause += (delta / 2)
-
-			// Ensure pause stays within bounds. On a permanent deficit, it would
-			// run negative and overflow at some point.
-			pause = min(max(pause, -args.interval), args.interval)
-		}
-	}
-}
-
-func reader(ctx context.Context, cancel context.CancelFunc, conn net.Conn, request []byte) func() error {
-	return func() error {
-		// Stop the reader when the writer is done, or the ErrGroup will wait forever.
-		defer cancel()
-
-		last := time.Now()
-		reply := make([]byte, internal.MsgSize)
-		for {
-			if err := conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
-				return fmt.Errorf("set read deadline: %w", err)
-			}
-
-			_, err := io.ReadFull(conn, reply)
-			// Allow the reader to drain replies before shutting down instead of
-			// closing the connection immediately. This reduces the chance of the
-			// server seeing a connection reset, which causes red herrings in the
-			// server logs when finding potential conn disruptions.
-			if errors.Is(err, os.ErrDeadlineExceeded) {
-				// Check if the deadline was exceeded as a consequence of shutting down.
-				// Require the reader to be fully caught up at this point.
-				select {
-				case <-ctx.Done():
-					if stats.tx.Load() == stats.rx.Load() {
-						fmt.Println("Reader shutting down")
-						return nil
-					}
-				default:
-				}
-
-				// Retry while the last reply was received within the timeout.
-				if time.Since(last) <= args.timeout {
-					continue
-				}
-
-				return fmt.Errorf("no reply received within %v timeout: %w", args.timeout, err)
-			}
-			if errors.Is(err, io.EOF) {
-				fmt.Println("Server closed the connection")
-				return nil
-			}
-			if err != nil {
-				return fmt.Errorf("read reply: %w", err)
-			}
-
-			if !bytes.Equal(request, reply) {
-				return fmt.Errorf("invalid reply(%v) to request(%v)", reply, request)
-			}
-
-			last = time.Now()
-			stats.rx.Add(1)
-			stats.bytes.Add(internal.MsgSize)
-
-			// Check if we're shutting down and reader fully caught up to the writer,
-			// for a fast exit.
-			select {
-			case <-ctx.Done():
-				if stats.tx.Load() == stats.rx.Load() {
-					fmt.Println("Reader shutting down")
-					return nil
-				}
-			default:
-			}
-		}
-	}
-}
-
-func ready() {
-	file, err := os.Create("/tmp/client-ready")
-	internal.ErrExit("create ready file", err)
-	internal.ErrExit("close ready file", file.Close())
+	handler.Run(ctx, cancel)
 }

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/test-connection-disruption/internal"
 	"github.com/cilium/test-connection-disruption/pkg/common"
+	"github.com/cilium/test-connection-disruption/pkg/http"
 	"github.com/cilium/test-connection-disruption/pkg/tcp"
 )
 
@@ -43,6 +44,8 @@ func main() {
 	switch common.Protocol(cc.Protocol) {
 	case common.ProtocolTCP:
 		handler = tcp.NewTcpClient(cc)
+	case common.ProtocolHTTP:
+		handler = http.NewHttpClient(cc)
 	default:
 		fmt.Printf("Invalid Protocol: %s\n", cc.Protocol)
 		os.Exit(1)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,16 +2,15 @@ package main
 
 import (
 	"context"
-	"errors"
-	"flag"
 	"fmt"
-	"io"
-	"net"
 	"os"
 	"os/signal"
-	"sync"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/cilium/test-connection-disruption/internal"
+	"github.com/cilium/test-connection-disruption/pkg/common"
+	"github.com/cilium/test-connection-disruption/pkg/tcp"
 )
 
 func init() {
@@ -19,98 +18,27 @@ func init() {
 }
 
 func main() {
+	sc := common.ServerConfig{}
+	sc.RegisterFlags()
 	flag.Parse()
-	port := flag.Arg(0)
-	if port == "" {
-		fmt.Println("Usage: server <port>")
+
+	sc.ProtocolConfig.Address = flag.Arg(0)
+	if sc.ProtocolConfig.Address == "" {
+		fmt.Println("Usage: server --protocol <tcp> <port/address>")
+		flag.Usage()
 		os.Exit(1)
 	}
 
-	listen, err := net.Listen("tcp", ":"+port)
-	internal.ErrExit("listen", err)
+	var handler common.ProtocolHandler
 
-	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
-	go func() {
-		<-ctx.Done()
-		fmt.Println("Closing listener")
-		listen.Close()
-	}()
+	switch common.Protocol(sc.Protocol) {
+	case common.ProtocolTCP:
+		handler = tcp.NewTcpServer(sc)
+	default:
+		fmt.Printf("Invalid Protocol: %s\n", sc.Protocol)
+		os.Exit(1)
+	}
 
-	ready()
-
-	fmt.Printf("Listening on port %s...\n", port)
-
-	wg := &sync.WaitGroup{}
-	accept(ctx, wg, listen)
-
-	wg.Wait()
-}
-
-func accept(ctx context.Context, wg *sync.WaitGroup, listen net.Listener) {
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-
-		for {
-			conn, err := listen.Accept()
-			if errors.Is(err, net.ErrClosed) {
-				fmt.Println("Listener closed")
-				return
-			}
-			internal.ErrExit("accept conn", err)
-
-			read(ctx, wg, conn)
-		}
-	}()
-}
-
-func read(ctx context.Context, wg *sync.WaitGroup, conn net.Conn) {
-	wg.Add(1)
-
-	ctx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-ctx.Done()
-		fmt.Println("Closing connection to", conn.RemoteAddr())
-		conn.Close()
-	}()
-
-	go func() {
-		defer wg.Done()
-
-		// Make sure context done channel unblocks when the reader exits so we don't
-		// leak the goroutine created above.
-		defer cancel()
-
-		fmt.Println("New connection from", conn.RemoteAddr())
-		defer conn.Close()
-
-		// Read+write one message at a time.
-		buf := make([]byte, internal.MsgSize)
-		for {
-			_, err := io.ReadFull(conn, buf)
-			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
-				return
-			}
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error reading from %s: %s\n", conn.RemoteAddr(), err)
-				return
-			}
-
-			_, err = conn.Write(buf)
-			if errors.Is(err, net.ErrClosed) {
-				return
-			}
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error writing to %s: %s\n", conn.RemoteAddr(), err)
-				return
-			}
-		}
-	}()
-}
-
-func ready() {
-	file, err := os.Create("/tmp/server-ready")
-	internal.ErrExit("create ready file", err)
-	internal.ErrExit("close ready file", file.Close())
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	handler.Run(ctx, cancel)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/test-connection-disruption/internal"
 	"github.com/cilium/test-connection-disruption/pkg/common"
+	"github.com/cilium/test-connection-disruption/pkg/http"
 	"github.com/cilium/test-connection-disruption/pkg/tcp"
 )
 
@@ -34,6 +35,8 @@ func main() {
 	switch common.Protocol(sc.Protocol) {
 	case common.ProtocolTCP:
 		handler = tcp.NewTcpServer(sc)
+	case common.ProtocolHTTP:
+		handler = http.NewHttpServer(sc)
 	default:
 		fmt.Printf("Invalid Protocol: %s\n", sc.Protocol)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/test-connection-disruption
 
-go 1.24.0
+go 1.25.3
 
 require (
 	github.com/spf13/pflag v1.0.10

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"context"
+	"time"
+
+	flag "github.com/spf13/pflag"
+)
+
+type Protocol string
+
+const (
+	ProtocolTCP Protocol = "tcp"
+)
+
+type ProtocolConfig struct {
+	Protocol string
+	Address  string
+}
+
+func (pc *ProtocolConfig) RegisterFlags() {
+	flag.StringVar(&pc.Protocol, "protocol", string(ProtocolTCP), "Transport protocol to use")
+}
+
+type ServerConfig struct {
+	ProtocolConfig
+}
+
+func (sc *ServerConfig) RegisterFlags() {
+	sc.ProtocolConfig.RegisterFlags()
+}
+
+type ClientConfig struct {
+	ProtocolConfig
+
+	Interval time.Duration
+	Timeout  time.Duration
+}
+
+func (cc *ClientConfig) RegisterFlags() {
+	cc.ProtocolConfig.RegisterFlags()
+
+	flag.DurationVar(&cc.Interval, "dispatch-interval", 50*time.Millisecond, "Client request dispatch interval")
+	flag.DurationVar(&cc.Timeout, "timeout", 5*time.Second, "Client exits when no reply is received within this duration")
+}
+
+type ProtocolHandler interface {
+	Run(ctx context.Context, cancel context.CancelFunc)
+}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -10,7 +10,8 @@ import (
 type Protocol string
 
 const (
-	ProtocolTCP Protocol = "tcp"
+	ProtocolTCP  Protocol = "tcp"
+	ProtocolHTTP Protocol = "http"
 )
 
 type ProtocolConfig struct {

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"os"
+
+	"github.com/cilium/test-connection-disruption/internal"
+)
+
+func MarkServerReady() {
+	file, err := os.Create("/tmp/server-ready")
+	internal.ErrExit("create ready file", err)
+	internal.ErrExit("close ready file", file.Close())
+}
+
+func MarkClientReady() {
+	file, err := os.Create("/tmp/client-ready")
+	internal.ErrExit("create ready file", err)
+	internal.ErrExit("close ready file", file.Close())
+}

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -1,0 +1,100 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"github.com/cilium/test-connection-disruption/internal"
+	"github.com/cilium/test-connection-disruption/pkg/common"
+)
+
+type HttpClient struct {
+	config common.ClientConfig
+
+	requestsCount atomic.Uint64
+}
+
+func NewHttpClient(config common.ClientConfig) *HttpClient {
+	return &HttpClient{config: config, requestsCount: atomic.Uint64{}}
+}
+
+func (c *HttpClient) Run(ctx context.Context, _ context.CancelFunc) {
+	fmt.Printf("Starting HTTP Client with config: %v\n", c.config)
+
+	request := make([]byte, internal.MsgSize)
+	_, err := rand.Read(request)
+	internal.ErrExit("generate random payload", err)
+
+	client := nethttp.Client{
+		Transport: &nethttp.Transport{
+			DisableKeepAlives:   false,
+			MaxIdleConnsPerHost: 1,
+		},
+		Timeout: c.config.Timeout,
+	}
+
+	c.startLogger(ctx)
+	internal.ErrExit("client", c.start(ctx, client, request))
+}
+
+func (c *HttpClient) start(ctx context.Context, client nethttp.Client, request []byte) error {
+	pause := c.config.Interval
+	runtime.LockOSThread()
+
+	fmt.Println("Sending requests at a target interval of", c.config.Interval, "with timeout of", c.config.Timeout)
+	common.MarkClientReady()
+	for {
+		// Immediately stop requests when the client is shutting down.
+		select {
+		case <-ctx.Done():
+			fmt.Println("Client shutting down")
+			return nil
+		default:
+		}
+
+		start := time.Now()
+		req, err := nethttp.NewRequest("GET", c.config.Address, bytes.NewReader(request))
+		if err != nil {
+			return fmt.Errorf("error creating request: %w", err)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return fmt.Errorf("http request failed: %w", err)
+		}
+
+		// Read the body entirely and close it to allow connection reuse (Keep-Alive).
+		_, discardErr := io.Copy(io.Discard, resp.Body)
+		internal.ErrExit("response body draining", discardErr)
+		internal.ErrExit("response body close", resp.Body.Close())
+
+		if resp.StatusCode != nethttp.StatusOK {
+			return fmt.Errorf("http request non success status code %d", resp.StatusCode)
+		}
+
+		c.requestsCount.Add(1)
+		internal.Pause(c.config.Interval, pause, start)
+	}
+}
+
+func (c *HttpClient) startLogger(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		for range ticker.C {
+			select {
+			case <-ctx.Done():
+				fmt.Println("Stopping Logger")
+				return
+			default:
+				fmt.Printf("Requests per second: %d/s\n", c.requestsCount.Swap(0))
+			}
+		}
+	}()
+}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -1,0 +1,64 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	nethttp "net/http"
+	"os"
+
+	"github.com/cilium/test-connection-disruption/internal"
+	"github.com/cilium/test-connection-disruption/pkg/common"
+)
+
+type HttpServer struct {
+	config common.ServerConfig
+}
+
+func NewHttpServer(config common.ServerConfig) *HttpServer {
+	return &HttpServer{config: config}
+}
+
+func (s *HttpServer) Run(ctx context.Context, _ context.CancelFunc) {
+	fmt.Printf("Starting HTTP Server with config: %#v\n", s.config)
+
+	listener, err := net.Listen("tcp", ":"+s.config.Address)
+	internal.ErrExit("TcpServer listen", err)
+	defer listener.Close()
+
+	nethttp.HandleFunc("/", s.httpEcho)
+	server := &nethttp.Server{
+		Handler: http.DefaultServeMux,
+	}
+	waitCtx, waitCancel := context.WithCancel(context.Background())
+	go func() {
+		defer waitCancel()
+
+		<-ctx.Done()
+		fmt.Println("Closing HTTP Server")
+		internal.ErrExit("http server shutdown", server.Shutdown(waitCtx))
+	}()
+
+	common.MarkServerReady()
+	err = server.Serve(listener)
+	internal.ErrExit("HttpServer listener", err)
+
+	<-waitCtx.Done()
+}
+
+func (s *HttpServer) httpEcho(w nethttp.ResponseWriter, r *nethttp.Request) {
+	fmt.Printf("New HTTP request: %s (%s)\n", r.URL.String(), r.Method)
+
+	w.Header().Set("X-Echo-Server", "Test-Connection-Disruption")
+	w.WriteHeader(nethttp.StatusOK)
+
+	_, err := io.Copy(w, r.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error copying request body: %s\n", r.URL)
+		return
+	}
+
+	r.Body.Close()
+}

--- a/pkg/tcp/client.go
+++ b/pkg/tcp/client.go
@@ -1,0 +1,225 @@
+package tcp
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cilium/test-connection-disruption/internal"
+	"github.com/cilium/test-connection-disruption/pkg/common"
+)
+
+const maxAttempts = 30
+
+type clientStats struct {
+	rx, tx atomic.Uint64
+	bytes  atomic.Uint64
+}
+
+type TcpClient struct {
+	config common.ClientConfig
+	stats  clientStats
+}
+
+func NewTcpClient(config common.ClientConfig) *TcpClient {
+	return &TcpClient{
+		config: config,
+		stats:  clientStats{rx: atomic.Uint64{}, tx: atomic.Uint64{}, bytes: atomic.Uint64{}},
+	}
+}
+
+func (c *TcpClient) Run(ctx context.Context, cancel context.CancelFunc) {
+	fmt.Printf("Starting TCP Client with config: %#v\n", c.config)
+
+	conn, err := c.dial()
+	internal.ErrExit("dial remote", err)
+	defer conn.Close()
+
+	// Set up request payload.
+	request := make([]byte, internal.MsgSize)
+	_, err = rand.Read(request)
+	internal.ErrExit("generate random payload", err)
+
+	var eg errgroup.Group
+	eg.Go(c.writer(ctx, cancel, conn, request))
+	eg.Go(c.reader(ctx, cancel, conn, request))
+
+	c.startLogger(ctx)
+
+	common.MarkClientReady()
+	internal.ErrExit("Error in writer or reader", eg.Wait())
+}
+
+func (c *TcpClient) startLogger(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		for range ticker.C {
+			select {
+			case <-ctx.Done():
+				fmt.Println("Stopping Logger")
+				return
+			default:
+				fmt.Printf("Operations per second: tx %d, rx %d, %s/s\n", c.stats.tx.Swap(0), c.stats.rx.Swap(0), internal.ByteString(c.stats.bytes.Swap(0)))
+			}
+		}
+	}()
+}
+
+func (c *TcpClient) dial() (net.Conn, error) {
+	var conn net.Conn
+	var err error
+	for range maxAttempts {
+		conn, err = net.Dial("tcp", c.config.Address)
+		if err == nil {
+			break
+		}
+		fmt.Printf("Failed to connect to %s due to %s. Retrying...\n", c.config.Address, err)
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("Connected to %s from %s\n", conn.RemoteAddr(), conn.LocalAddr())
+
+	return conn, nil
+}
+
+func (c *TcpClient) writer(ctx context.Context, cancel context.CancelFunc, conn net.Conn, request []byte) func() error {
+	return func() error {
+		// Stop the reader when the writer is done, or the ErrGroup will wait forever.
+		defer cancel()
+
+		// Start off with the configured packet interval. This will be adjusted
+		// based on the time it took to write to the socket.
+		pause := c.config.Interval
+
+		// Lock the goroutine to the current OS thread to prevent the runtime from
+		// migrating and interrupting it as often. We're manually calling nanosleep,
+		// bypassing the runtime's scheduler, to get somewhat accurate sleep
+		// behaviour.
+		runtime.LockOSThread()
+
+		fmt.Println("Sending requests at a target interval of", c.config.Interval, "with timeout of", c.config.Timeout)
+
+		for {
+			// Immediately stop producing packets when the client is shutting down.
+			select {
+			case <-ctx.Done():
+				fmt.Println("Writer shutting down")
+				return nil
+			default:
+			}
+
+			start := time.Now()
+
+			if err := conn.SetWriteDeadline(start.Add(time.Second)); err != nil {
+				return fmt.Errorf("set write deadline: %w", err)
+			}
+
+			n, err := conn.Write(request)
+			if err != nil {
+				return fmt.Errorf("conn write: %w", err)
+			}
+			if n != len(request) {
+				return fmt.Errorf("short write: %d", n)
+			}
+
+			c.stats.tx.Add(1)
+
+			// Sleep for the duration determined during the previous round. Use a
+			// direct call to nanosleep(2) since the regular [time.Sleep] is
+			// implemented by the Go runtime and gets coalesced to reduce syscall
+			// overhead. This leads to wildly unexpected sleep durations.
+			internal.Sleep(pause)
+
+			// Adjust the sleep interval for the next cycle based on the time it took
+			// to write to the socket and when the OS scheduler woke us up.
+			delta := c.config.Interval - time.Since(start)
+
+			// Smoothen the approach to the target interval by adjusting the pause
+			// interval by half the delta.
+			pause += (delta / 2)
+
+			// Ensure pause stays within bounds. On a permanent deficit, it would
+			// run negative and overflow at some point.
+			pause = min(max(pause, -c.config.Interval), c.config.Interval)
+		}
+	}
+}
+
+func (c *TcpClient) reader(ctx context.Context, cancel context.CancelFunc, conn net.Conn, request []byte) func() error {
+	return func() error {
+		// Stop the reader when the writer is done, or the ErrGroup will wait forever.
+		defer cancel()
+
+		last := time.Now()
+		reply := make([]byte, internal.MsgSize)
+		for {
+			if err := conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond)); err != nil {
+				return fmt.Errorf("set read deadline: %w", err)
+			}
+
+			_, err := io.ReadFull(conn, reply)
+			// Allow the reader to drain replies before shutting down instead of
+			// closing the connection immediately. This reduces the chance of the
+			// server seeing a connection reset, which causes red herrings in the
+			// server logs when finding potential conn disruptions.
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				// Check if the deadline was exceeded as a consequence of shutting down.
+				// Require the reader to be fully caught up at this point.
+				select {
+				case <-ctx.Done():
+					if c.stats.tx.Load() == c.stats.rx.Load() {
+						fmt.Println("Reader shutting down")
+						return nil
+					}
+				default:
+				}
+
+				// Retry while the last reply was received within the timeout.
+				if time.Since(last) <= c.config.Timeout {
+					continue
+				}
+
+				return fmt.Errorf("no reply received within %v timeout: %w", c.config.Timeout, err)
+			}
+			if errors.Is(err, io.EOF) {
+				fmt.Println("Server closed the connection")
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("read reply: %w", err)
+			}
+
+			if !bytes.Equal(request, reply) {
+				return fmt.Errorf("invalid reply(%v) to request(%v)", reply, request)
+			}
+
+			last = time.Now()
+			c.stats.rx.Add(1)
+			c.stats.bytes.Add(internal.MsgSize)
+
+			// Check if we're shutting down and reader fully caught up to the writer,
+			// for a fast exit.
+			select {
+			case <-ctx.Done():
+				if c.stats.tx.Load() == c.stats.rx.Load() {
+					fmt.Println("Reader shutting down")
+					return nil
+				}
+			default:
+			}
+		}
+	}
+}

--- a/pkg/tcp/client.go
+++ b/pkg/tcp/client.go
@@ -39,7 +39,7 @@ func NewTcpClient(config common.ClientConfig) *TcpClient {
 }
 
 func (c *TcpClient) Run(ctx context.Context, cancel context.CancelFunc) {
-	fmt.Printf("Starting TCP Client with config: %#v\n", c.config)
+	fmt.Printf("Starting TCP Client with config: %v\n", c.config)
 
 	conn, err := c.dial()
 	internal.ErrExit("dial remote", err)

--- a/pkg/tcp/server.go
+++ b/pkg/tcp/server.go
@@ -1,0 +1,105 @@
+package tcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/cilium/test-connection-disruption/internal"
+	"github.com/cilium/test-connection-disruption/pkg/common"
+)
+
+type TcpServer struct {
+	config common.ServerConfig
+}
+
+func NewTcpServer(config common.ServerConfig) *TcpServer {
+	return &TcpServer{config: config}
+}
+
+func (s *TcpServer) Run(ctx context.Context, _ context.CancelFunc) {
+	fmt.Printf("Starting TCP Server with config: %#v\n", s.config)
+
+	listen, err := net.Listen("tcp", ":"+s.config.Address)
+	internal.ErrExit("TcpServer listen", err)
+
+	go func() {
+		<-ctx.Done()
+		fmt.Println("Closing listener")
+		listen.Close()
+	}()
+
+	common.MarkServerReady()
+
+	wg := &sync.WaitGroup{}
+	s.accept(ctx, wg, listen)
+
+	wg.Wait()
+}
+
+func (s *TcpServer) accept(ctx context.Context, wg *sync.WaitGroup, listen net.Listener) {
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for {
+			conn, err := listen.Accept()
+			if errors.Is(err, net.ErrClosed) {
+				fmt.Println("Listener closed")
+				return
+			}
+			internal.ErrExit("accept conn", err)
+
+			s.read(ctx, wg, conn)
+		}
+	}()
+}
+
+func (s *TcpServer) read(ctx context.Context, wg *sync.WaitGroup, conn net.Conn) {
+	wg.Add(1)
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-ctx.Done()
+		fmt.Println("Closing connection to", conn.RemoteAddr())
+		conn.Close()
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// Make sure context done channel unblocks when the reader exits so we don't
+		// leak the goroutine created above.
+		defer cancel()
+
+		fmt.Println("New connection from", conn.RemoteAddr())
+		defer conn.Close()
+
+		// Read+write one message at a time.
+		buf := make([]byte, internal.MsgSize)
+		for {
+			_, err := io.ReadFull(conn, buf)
+			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading from %s: %s\n", conn.RemoteAddr(), err)
+				return
+			}
+
+			_, err = conn.Write(buf)
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error writing to %s: %s\n", conn.RemoteAddr(), err)
+				return
+			}
+		}
+	}()
+}


### PR DESCRIPTION
* Add a new optional flag for client and server commands to specify the protocol - `--protocol`. Defaults to `tcp` to keep existing command behavior.
* Separate out client and server implementation from main command to package per protocol.
* Add http client and server protocol implementation.

Required for extending cilium cli connection disruption connectivity tests for L7 policy.

Test Docker Image: `docker.io/fristonio/test-connection-disruption:v0.0.17`
Cilium PR: https://github.com/cilium/cilium/pull/42150
CI validation:  https://github.com/cilium/cilium/actions/runs/18918259228