### PR TITLE
Add containerdisk variant for KubeVirt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILDER
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.25 AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.26 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN make clean
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} make
 
 # RUNTIME
-FROM --platform=${TARGETPLATFORM:-linux/amd64} busybox
+FROM busybox
 COPY --from=builder /src/test-connection-disruption/client /usr/bin/tcd-client
 COPY --from=builder /src/test-connection-disruption/server /usr/bin/tcd-server

--- a/Dockerfile.containerdisk
+++ b/Dockerfile.containerdisk
@@ -1,0 +1,31 @@
+ARG BASEIMAGE=invalid_base_image
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+
+# BASEIMAGE
+FROM ${BASEIMAGE} AS baseimage
+
+# BUILDER
+# Note: This stage runs on the build (and not the target) platform,
+# because libguestfs spawns a mini-VM to be able to create and write ext4 images and
+# that requires a native builder.
+FROM --platform=${BUILDPLATFORM:-linux/amd64} quay.io/kubevirt/libguestfs-tools:v1.8.4 AS guestfs
+
+ENV LIBGUESTFS_BACKEND=direct
+ENV LIBGUESTFS_PATH=/usr/local/lib/guestfs/appliance
+ENV LIBGUESTFS_TMPDIR=/tmp/guestfs
+ENV HOME=/home/guestfs
+
+# Extract conndisrupt binaries from baseimage into the /conndisrupt folder
+COPY --from=baseimage /usr/bin/tcd-client /conndisrupt/
+COPY --from=baseimage /usr/bin/tcd-server /conndisrupt/
+
+# Create an ext4 disk image from the /conndisrupt folder
+RUN --mount=type=cache,mode=0755,uid=1001,gid=0,target=/home/guestfs \
+    --mount=type=cache,mode=0755,uid=1001,gid=0,target=/tmp/guestfs \
+    virt-make-fs /conndisrupt --type=ext4 --format=qcow2 --label=conndisrupt /tmp/conndisrupt.img
+
+# CONTAINERDISK
+# Provide the disk image in the format expected by KubeVirt
+FROM scratch
+COPY --from=guestfs /tmp/conndisrupt.img /disk/conndisrupt.img

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GO ?= go
-TAG ?= v0.0.17
+TAG ?= v0.0.18
 IMAGE ?= quay.io/cilium/test-connection-disruption
 GOOS ?= linux
 GOARCH ?= amd64

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,11 @@ publish:
 		--platform linux/amd64,linux/arm64 \
 		--output "type=image,push=true" \
 		--tag $(IMAGE):$(TAG) .
+
+	@docker buildx create --use --name=crossplatform --node=crossplatform && \
+	docker buildx build \
+		--file Dockerfile.containerdisk \
+		--build-arg BASEIMAGE=$(IMAGE):$(TAG) \
+		--platform linux/amd64,linux/arm64 \
+		--output "type=image,push=true" \
+		--tag $(IMAGE):$(TAG)-containerdisk .

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	rm -f client server
 
 .PHONY: image
-image: client server
+image:
 	docker build --tag $(IMAGE):$(TAG) .
 
 .PHONY: publish

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/cilium/test-connection-disruption
 
-go 1.25.3
+go 1.26.5
 
 require (
 	github.com/spf13/pflag v1.0.10
-	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
-	golang.org/x/sync v0.18.0
+	golang.org/x/exp v0.0.0-20260727155853-b88d891fe743
+	golang.org/x/sync v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=
-golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
-golang.org/x/sync v0.18.0 h1:kr88TuHDroi+UVf+0hZnirlk8o8T+4MrK6mr60WkH/I=
-golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/exp v0.0.0-20260727155853-b88d891fe743 h1:ex206bKw+v3K0dm3andkrIF+ijyQKJG1pLgwQ2PYdQM=
+golang.org/x/exp v0.0.0-20260727155853-b88d891fe743/go.mod h1:EdfpwwqSu+0Li0mzskwHU6FWDV3t9Q+RZDo3QMUtL3Q=
+golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -109,7 +109,7 @@ func (g *Group) TryGo(f func() error) bool {
 	if g.sem != nil {
 		select {
 		case g.sem <- token{}:
-			// Note: this allows barging iff channels in general allow barging.
+			// Note: this allows barging if and only if channels in general allow barging.
 		default:
 			return false
 		}
@@ -144,8 +144,8 @@ func (g *Group) SetLimit(n int) {
 		g.sem = nil
 		return
 	}
-	if len(g.sem) != 0 {
-		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	if active := len(g.sem); active != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", active))
 	}
 	g.sem = make(chan token, n)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,9 +1,9 @@
 # github.com/spf13/pflag v1.0.10
 ## explicit; go 1.12
 github.com/spf13/pflag
-# golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
-## explicit; go 1.24.0
+# golang.org/x/exp v0.0.0-20260727155853-b88d891fe743
+## explicit; go 1.25.0
 golang.org/x/exp/constraints
-# golang.org/x/sync v0.18.0
-## explicit; go 1.24.0
+# golang.org/x/sync v0.22.0
+## explicit; go 1.25.0
 golang.org/x/sync/errgroup


### PR DESCRIPTION
This PR adds a new Docker image variant, the `-containerdisk` variant. A containerdisk is a OCI container image that contains a qcow2 iamge to be mounted inside a KubeVirt VM.

While at it, also do some spring cleanup.