### PR TITLE
client: honour --timeout for the TCP write deadline

### DIFF
--- a/pkg/tcp/client.go
+++ b/pkg/tcp/client.go
@@ -123,7 +123,14 @@ func (c *TcpClient) writer(ctx context.Context, cancel context.CancelFunc, conn 
 
 			start := time.Now()
 
-			if err := conn.SetWriteDeadline(start.Add(time.Second)); err != nil {
+			// Use the configured timeout rather than a fixed one second. This
+			// client runs a writer and a reader goroutine over the same conn,
+			// and the reader retries while the last reply arrived within
+			// c.config.Timeout. A hardcoded write deadline therefore made the
+			// writer the strictest part of the client: a transient stall of
+			// just over a second terminated it, while the same stall on the
+			// read side was retried.
+			if err := conn.SetWriteDeadline(start.Add(c.config.Timeout)); err != nil {
 				return fmt.Errorf("set write deadline: %w", err)
 			}
 


### PR DESCRIPTION
The client runs a writer and a reader goroutine over the same connection, and either one returning an error terminates the client through `eg.Wait()`. The reader retries a read deadline expiry while the last reply arrived within `--timeout`, which defaults to 5s, but the writer used a hardcoded one second deadline that `--timeout` did not govern. That made the writer the strictest part of the client: a transient stall of just over a second on a socket write ended it with `conn write: write tcp ...: i/o timeout`, while the same stall on the read side would have been retried.

This turned up in cilium's e2e-upgrade CI on an ipsec leg, where the plain conn-disrupt client exited during a downgrade after running at a steady 100 ops/s, which fails `no-interrupted-connections` on a restart count mismatch. Cilium's own Envoy logs on the L7 variant of the same suite show upstream replies with a p50 of 10ms but a tail reaching 4.9s during an agent restart, so a sub-second write stall is well within what that environment produces.

This uses `c.config.Timeout` for the write deadline so both directions share one configurable bound. The client still exits on a genuine failure, and anyone leaving `--timeout` at its default just gets 5s on the write side instead of 1s.

Worth flagging for review: this is a behaviour change for every consumer, not only CI, and I have not been able to verify it end to end since that needs a rebuilt image and a version bump in cilium-cli defaults. The reasoning is from the code asymmetry plus one matching CI failure. The related cilium-side change is cilium/cilium#47440, which raises the conn-disrupt client timeout for the L7 clients.

This PR was prepared with AIL:3.
